### PR TITLE
Add auto-promotion for NET-wrapping interfaces

### DIFF
--- a/interfaces.zen
+++ b/interfaces.zen
@@ -1,5 +1,5 @@
 Analog = interface(
-    NET = Net(),
+    NET = using(Net()),
 )
 
 Can = interface(
@@ -115,11 +115,11 @@ Ethernet_1000BaseT = interface(
 )
 
 Gpio = interface(
-    NET = Net(),
+    NET = using(Net()),
 )
 
 Ground = interface(
-    NET = Net("GND", symbol = Symbol(library = "@kicad-symbols/power.kicad_sym", name = "GND")),
+    NET = using(Net("GND", symbol = Symbol(library = "@kicad-symbols/power.kicad_sym", name = "GND"))),
 )
 
 Hdmi = interface(
@@ -303,11 +303,11 @@ PcieGen3x2Lane = interface(
 )
 
 Power = interface(
-    NET = Net("VCC", symbol = Symbol(library = "@kicad-symbols/power.kicad_sym", name = "VCC")),
+    NET = using(Net("VCC", symbol = Symbol(library = "@kicad-symbols/power.kicad_sym", name = "VCC"))),
 )
 
 Pwm = interface(
-    NET = Net(),
+    NET = using(Net()),
 )
 
 QLink = interface(


### PR DESCRIPTION
This is only the backwards-compatible subset of changes.