### PR TITLE
Add `voltage_within()` check

### DIFF
--- a/checks.zen
+++ b/checks.zen
@@ -1,0 +1,31 @@
+load("units.zen", "VoltageRange")
+load("interfaces.zen", "Power")
+
+Severity = enum("error", "warning", "advice")
+
+
+def voltage_within(
+    within: str | VoltageRange, name: str = "voltage_check", severity: Severity = Severity("error")
+) -> typing.Callable:
+    def ensure_voltage_within(_module, net_name: str, voltage: VoltageRange, within: str | VoltageRange):
+        within = VoltageRange(within)
+        # drop nominal in within:
+        within = VoltageRange(min=within.min, max=within.max)
+        # ensure voltage is within within
+        min_valid = voltage.min >= within.min
+        max_valid = voltage.max <= within.max
+        err_msg = "Voltage range " + str(voltage) + " of " + net_name + " is not within " + str(within)
+        check(min_valid and max_valid, err_msg)
+
+    def check_gen(power: Power, severity: Severity = severity, name: str = name):
+        check_name = power.NET.name + "_" + name
+        if not power.voltage:
+            return
+        builtin.add_electrical_check(
+            name=check_name,
+            check_fn=ensure_voltage_within,
+            inputs={"voltage": power.voltage, "within": within, "net_name": power.NET.name},
+            severity=severity.value,
+        )
+
+    return check_gen

--- a/interfaces.zen
+++ b/interfaces.zen
@@ -1,3 +1,5 @@
+load("units.zen", "VoltageRange")
+
 Analog = interface(
     NET=using(Net()),
 )
@@ -312,6 +314,7 @@ PcieGen3x2Lane = interface(
 
 Power = interface(
     NET=using(Net("VCC", symbol=Symbol(library="@kicad-symbols/power.kicad_sym", name="VCC"))),
+    voltage=field(VoltageRange | None, None),
 )
 
 Pwm = interface(

--- a/units.zen
+++ b/units.zen
@@ -16,6 +16,16 @@ Energy = builtin.Energy
 MagneticFlux = builtin.MagneticFlux
 Conductance = builtin.Conductance
 
+VoltageRange = builtin.physical_range("V")
+CurrentRange = builtin.physical_range("A")
+ResistanceRange = builtin.physical_range("Ohm")
+CapacitanceRange = builtin.physical_range("F")
+InductanceRange = builtin.physical_range("H")
+FrequencyRange = builtin.physical_range("Hz")
+TemperatureRange = builtin.physical_range("K")
+TimeRange = builtin.physical_range("s")
+PowerRange = builtin.physical_range("W")
+
 
 def unit(spec, type):
     return type(spec)


### PR DESCRIPTION
usage:

```starlark
# child module
load("@stdlib/checks.zen", "voltage_within")
vbat = io("VBAT", Power, voltage_within("3.3–4.2V"))
```

```starlark
# parent module
Child = Module("./child.zen")

VBAT = Power("VBAT", voltage="3.3–5V")
Child(name = "child", VBAT = VBAT)
```
^ example of what would cause an ERC check failure