### PR TITLE
Unify + document default stackups

### DIFF
--- a/board_config.zen
+++ b/board_config.zen
@@ -292,10 +292,32 @@ BASE_PREPREG = Material(
     loss_tangent=0.025,  # Standard prepreg material
 )
 
+# Stackup Design Philosophy
+#
+# Layer convention for 4L/6L/8L stackups:
+#   - First 3 layers: SIG/GND/PWR (always)
+#   - Last layer: SIG (always)
+#
+# This enables module reusability - a 4L module can be ported to 6L/8L by using the
+# same top 3 layers and bottom layer. Internal layers provide additional routing.
+#
+# Impedance Control:
+#   - GCPW (Grounded Coplanar Waveguide) for all impedance-controlled routing
+#   - L1 (top) is primary impedance-controlled layer
+#   - L6/L8 (bottom) serve as backup impedance-controlled layers on 6L/8L
+#   - 8L also provides L6 as symmetric stripline (GND/SIG/GND)
+#
+# Selection:
+#   - 2L: Simple, low speed
+#   - 4L: Standard, L1 impedance-controlled
+#   - 6L: More routing, L1 + L6 impedance-controlled
+#   - 8L: High density, L1 + L6 (stripline) + L8 impedance-controlled
+
 # Common stackup configurations
 
 # Base 2-layer stackup (1.6mm, 1oz outer)
 # SIG/SIG
+# Use case: Simple designs without dedicated power/ground planes
 BASE_2L_STACKUP = Stackup(
     materials=[FR4_CORE],
     thickness=1.6,
@@ -312,6 +334,14 @@ BASE_2L_STACKUP = Stackup(
 
 # Base 4-layer stackup (1.6mm, 1oz outer/0.5oz inner)
 # SIG/GND/PWR/SIG
+#
+# Layers:
+#   L1: Mixed + impedance-controlled (GCPW, ref L2, 0.21mm coupling)
+#   L2: GND plane
+#   L3: PWR plane
+#   L4: Mixed signal
+#
+# Use: Standard stackup with dedicated GND/PWR planes. L1 for high-speed routing.
 BASE_4L_STACKUP = Stackup(
     materials=[FR4_CORE, BASE_PREPREG],
     thickness=1.6,
@@ -322,7 +352,7 @@ BASE_4L_STACKUP = Stackup(
     layers=[
         CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
         DielectricLayer(thickness=0.21040, material="Prepreg", form="prepreg"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L2 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L2 (0.5oz)
         DielectricLayer(thickness=1.065, material="FR4-Core", form="core"),
         CopperLayer(thickness=0.0152, role="power"),  # Inner L3 (0.5oz)
         DielectricLayer(thickness=0.21040, material="Prepreg", form="prepreg"),
@@ -331,7 +361,17 @@ BASE_4L_STACKUP = Stackup(
 )
 
 # Base 6-layer stackup (1.6mm, 1oz outer/0.5oz inner)
-# SIG/GND/(SIG/PWR)/(SIG/PWR)/GND/SIG
+# SIG/GND/PWR/SIG/GND/SIG
+#
+# Layers:
+#   L1: Primary impedance-controlled (GCPW, ref L2, 0.099mm coupling)
+#   L2: GND plane
+#   L3: PWR plane
+#   L4: Mixed signal
+#   L5: GND plane
+#   L6: Backup impedance-controlled (GCPW, ref L5, 0.099mm coupling)
+#
+# Use: More routing space than 4L. Two ground planes for return paths.
 BASE_6L_STACKUP = Stackup(
     materials=[
         FR4_CORE,
@@ -354,20 +394,32 @@ BASE_6L_STACKUP = Stackup(
     layers=[
         CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
         DielectricLayer(thickness=0.09940, material="3313", form="prepreg"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L2 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L2 (0.5oz)
         DielectricLayer(thickness=0.55, material="FR4-Core", form="core"),
-        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L3 (0.5oz)
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L3 (0.5oz)
         DielectricLayer(thickness=0.11640, material="2116", form="prepreg"),
         CopperLayer(thickness=0.0152, role="mixed"),  # Inner L4 (0.5oz)
         DielectricLayer(thickness=0.55, material="FR4-Core", form="core"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L5 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L5 (0.5oz)
         DielectricLayer(thickness=0.09940, material="3313", form="prepreg"),
         CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
     ],
 )
 
 # Base 8-layer stackup (1.6mm, 1oz outer/0.5oz inner)
-# SIG/GND/SIG/PWR/GND/SIG/GND/SIG
+# SIG/GND/PWR/SIG/GND/SIG/GND/SIG
+#
+# Layers:
+#   L1: Primary impedance-controlled (GCPW, ref L2, 0.116mm coupling)
+#   L2: GND plane
+#   L3: PWR plane
+#   L4: Mixed signal
+#   L5: GND plane
+#   L6: Secondary impedance-controlled (symmetric stripline, L5/L7 refs)
+#   L7: GND plane
+#   L8: Backup impedance-controlled (GCPW, ref L7)
+#
+# Use: High routing density. Three ground planes. L6 symmetric stripline for EMI control.
 BASE_8L_STACKUP = Stackup(
     materials=[
         FR4_CORE,
@@ -390,19 +442,19 @@ BASE_8L_STACKUP = Stackup(
     layers=[
         CopperLayer(thickness=0.035, role="mixed"),  # Top layer (1oz)
         DielectricLayer(thickness=0.1164, material="2116", form="prepreg"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L2 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L2 (0.5oz)
         DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
-        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L3 (0.5oz)
+        CopperLayer(thickness=0.0152, role="power"),  # Inner L3 (0.5oz)
         DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
         DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L4 (0.5oz)
+        CopperLayer(thickness=0.0152, role="mixed"),  # Inner L4 (0.5oz)
         DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L5 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L5 (0.5oz)
         DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
         DielectricLayer(thickness=0.0764, material="1080", form="prepreg"),
         CopperLayer(thickness=0.0152, role="mixed"),  # Inner L6 (0.5oz)
         DielectricLayer(thickness=0.3, material="FR4-Core", form="core"),
-        CopperLayer(thickness=0.0152, role="power"),  # Inner L7 (0.5oz)
+        CopperLayer(thickness=0.0152, role="ground"),  # Inner L7 (0.5oz)
         DielectricLayer(thickness=0.1164, material="2116", form="prepreg"),
         CopperLayer(thickness=0.035, role="mixed"),  # Bottom layer (1oz)
     ],


### PR DESCRIPTION
Use the new "ground" role to semantically distinguish ground planes from power planes. Explains the SIG/GND/PWR top-3 layer convention for module reusability. Documents the impedance-controlled layers and their reference planes.